### PR TITLE
Fix warning message when disconnected in ChatUI and settings modal

### DIFF
--- a/src/components/Chat/ChatMessages.tsx
+++ b/src/components/Chat/ChatMessages.tsx
@@ -2,6 +2,8 @@ import React, { useRef, useEffect } from 'react';
 import { Bot, User, AlertCircle } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import { Message } from '../../types';
+import { endpointManager } from '../../lib/endpoint';
+import { useChatStore } from '../../lib/store';
 
 interface ChatMessagesProps {
   messages: Message[];
@@ -10,6 +12,9 @@ interface ChatMessagesProps {
 
 export function ChatMessages({ messages, error }: ChatMessagesProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const { ollamaEndpoint } = useChatStore();
+  const health = ollamaEndpoint ? endpointManager.getHealth(ollamaEndpoint) : null;
+  const isDisconnected = !health?.isConnected;
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -17,7 +22,7 @@ export function ChatMessages({ messages, error }: ChatMessagesProps) {
 
   return (
     <div className="flex-1 overflow-y-auto p-4 space-y-4">
-      {error && (
+      {error && !isDisconnected && (
         <div className="bg-red-50 border-l-4 border-red-400 p-4">
           <div className="flex">
             <div className="flex-shrink-0">

--- a/src/components/Chat/SettingsModal.tsx
+++ b/src/components/Chat/SettingsModal.tsx
@@ -92,7 +92,7 @@ export function SettingsModal({
           </div>
         )}
 
-        {error && (
+        {error && health?.isConnected && (
           <div className="mt-4 p-3 bg-red-50 text-red-700 rounded-md flex items-start space-x-2">
             <AlertCircle className="h-5 w-5 flex-shrink-0 text-red-400" />
             <span className="text-sm">{error}</span>

--- a/src/components/Chat/index.tsx
+++ b/src/components/Chat/index.tsx
@@ -47,6 +47,7 @@ export function Chat() {
         // Clear models when disconnected
         setModels([]);
         setSelectedModel('');
+        setError(null); // Clear error message when disconnected
       }
     });
 
@@ -193,17 +194,22 @@ export function Chat() {
       const data = await response.json();
       setModels(data.models || []);
     } catch (error) {
-      const errorMessage = 'Failed to fetch available models. Please check your endpoint configuration.';
-      setError(errorMessage);
-      logError(errorMessage, {
-        endpoint,
-        error: error instanceof Error ? {
-          message: error.message,
-          name: error.name,
-          stack: error.stack
-        } : String(error)
-      });
-      console.error('Error fetching models:', error);
+      const health = endpointManager.getHealth(endpoint);
+      if (health?.isConnected) {
+        const errorMessage = 'Failed to fetch available models. Please check your endpoint configuration.';
+        setError(errorMessage);
+        logError(errorMessage, {
+          endpoint,
+          error: error instanceof Error ? {
+            message: error.message,
+            name: error.name,
+            stack: error.stack
+          } : String(error)
+        });
+        console.error('Error fetching models:', error);
+      } else {
+        setError(null); // Clear error message if disconnected
+      }
     } finally {
       setLoadingModels(false);
     }


### PR DESCRIPTION
Update the ChatUI and settings modal to not show the "Failed to fetch available models. Please check your endpoint configuration." warning when disconnected.

* **Chat/index.tsx**
  - Update `fetchModels` function to check if the endpoint is connected before setting the error message.
  - Clear the error message when disconnected.

* **SettingsModal.tsx**
  - Display the error message only if the endpoint is connected.

* **ChatMessages.tsx**
  - Do not display the error message when disconnected.

